### PR TITLE
Add metrics proxy deployment assets

### DIFF
--- a/tools/metrics_proxy/Dockerfile
+++ b/tools/metrics_proxy/Dockerfile
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONPATH=/app
+
+WORKDIR /app
+
+# Install runtime dependencies for the proxy server.
+RUN pip install --no-cache-dir fastapi "uvicorn[standard]" httpx prometheus-client
+
+# Copy only the pieces required to run the proxy.
+COPY tools/metrics_proxy /app/tools/metrics_proxy
+COPY vllm /app/vllm
+
+EXPOSE 8000
+
+ENTRYPOINT ["python", "-m", "tools.metrics_proxy.proxy_server"]

--- a/tools/metrics_proxy/README.md
+++ b/tools/metrics_proxy/README.md
@@ -1,0 +1,135 @@
+# vLLM Metrics Proxy Tools
+
+This directory contains a lightweight proxy and helper utilities that mirror vLLM's
+Prometheus metrics for OpenAI-compatible `/v1/chat/completions` traffic. The proxy sits
+in front of an existing vLLM (or any OpenAI-compatible) deployment, forwards requests to
+its upstream server, and records metrics such as queue time, time-to-first-token (TTFT),
+number of running/waiting requests, token counts, and success/error totals. The metrics
+can be scraped in Prometheus format or consumed as structured JSON for custom tooling.
+
+## Installation
+
+The proxy depends on FastAPI, httpx, uvicorn, and prometheus-client. Install the project
+in editable mode (recommended when working inside the repository) and include the
+runtime dependencies:
+
+```bash
+pip install -e .[dev]
+# or install only the required packages
+pip install fastapi uvicorn httpx prometheus-client
+```
+
+## Running the proxy server
+
+Launch the proxy by pointing it at an existing `/v1/chat/completions` endpoint and
+supplying the model name you want attached to emitted metrics:
+
+```bash
+python -m tools.metrics_proxy.proxy_server \
+  --upstream-url http://localhost:8001 \
+  --model-name my-model-name
+```
+
+Key flags you can tweak:
+
+* `--host` / `--port`: listening interface for the proxy (default `0.0.0.0:8000`).
+* `--engine-label`: value recorded in the `engine` Prometheus label (default `proxy`).
+* `--max-concurrency`: number of concurrent upstream requests the proxy allows before
+  new arrivals wait in the queue.
+* `--max-model-len`: maximum context window used to size latency/token histograms.
+* `--connect-timeout`, `--read-timeout`, `--write-timeout`, `--request-timeout`: HTTP
+  timeouts applied to upstream calls.
+* `--disable-metrics-endpoint`: omit the Prometheus `/metrics` endpoint when you only
+  need JSON snapshots.
+* `--log-level`: adjust proxy logging verbosity.
+
+The proxy exposes the following routes:
+
+* `POST /v1/chat/completions`: forwards regular or streaming chat completions to the
+  upstream server while tracking queue/inference durations and token usage.
+* `GET /internal/metrics`: returns a JSON snapshot of all counters, gauges, histograms,
+  and vectors maintained by the proxy (`ProxyMetricsRecorder.snapshot()`).
+* `GET /metrics`: (optional) renders metrics in Prometheus exposition format for a
+  scraper such as Prometheus or Grafana Agent.
+* `GET /internal/healthz`: simple health probe that returns `{ "status": "ok" }`.
+
+Each request generates an INFO-level summary log including queue time, inference time,
+TTFT (for streaming responses), and token usage to ease manual inspection.
+
+### Container image
+
+You can build a standalone container image for the proxy using the provided
+`tools/metrics_proxy/Dockerfile`:
+
+```bash
+docker build -f tools/metrics_proxy/Dockerfile -t ghcr.io/<org>/vllm-metrics-proxy .
+```
+
+The image entrypoint runs `python -m tools.metrics_proxy.proxy_server` so you can
+configure it via CLI arguments or the environment variables described below. A minimal
+`docker run` invocation that publishes the proxy on port 8000 looks like:
+
+```bash
+docker run --rm -p 8000:8000 \
+  -e PROXY_UPSTREAM_URL=http://vllm-backend:8000 \
+  -e PROXY_MODEL_NAME=my-model \
+  ghcr.io/<org>/vllm-metrics-proxy:latest
+```
+
+Environment variables map to the CLI flags for convenient container usage:
+
+| Environment variable | CLI flag | Description |
+| -------------------- | -------- | ----------- |
+| `PROXY_UPSTREAM_URL` | `--upstream-url` | Base URL of the upstream server (required). |
+| `PROXY_MODEL_NAME` | `--model-name` | Name of the served model used in metric labels (required). |
+| `PROXY_ENGINE_LABEL` | `--engine-label` | Override the `engine` Prometheus label. |
+| `PROXY_HOST` | `--host` | Bind address for the proxy. |
+| `PROXY_PORT` | `--port` | Listening port (default `8000`). |
+| `PROXY_MAX_CONCURRENCY` | `--max-concurrency` | Maximum concurrent upstream requests. |
+| `PROXY_MAX_MODEL_LEN` | `--max-model-len` | Histogram bucket sizing for token metrics. |
+| `PROXY_CONNECT_TIMEOUT` | `--connect-timeout` | Upstream connect timeout (seconds). |
+| `PROXY_READ_TIMEOUT` | `--read-timeout` | Upstream read timeout (seconds). |
+| `PROXY_WRITE_TIMEOUT` | `--write-timeout` | Upstream write timeout (seconds). |
+| `PROXY_REQUEST_TIMEOUT` | `--request-timeout` | Overall upstream request timeout (seconds). |
+| `PROXY_DISABLE_METRICS_ENDPOINT` | `--disable-metrics-endpoint` | Set to `true` to disable `/metrics`. |
+| `PROXY_LOG_LEVEL` | `--log-level` | Logging verbosity. |
+
+### Kubernetes deployment
+
+Sample Kubernetes manifests are available under `tools/metrics_proxy/kubernetes/` for
+deploying the proxy in front of an existing vLLM installation. The deployment uses the
+environment variables listed above to target the upstream service and exposes the HTTP
+probe endpoints for health checks.
+
+Apply the manifests (after updating the image name, model name, and upstream URL) with:
+
+```bash
+kubectl apply -f tools/metrics_proxy/kubernetes/
+```
+
+This will create a `Deployment` named `metrics-proxy` listening on port 8000 with a
+cluster `Service` exposing it on port 80. You can adjust resource requests/limits,
+replicas, or inject additional CLI overrides by editing the manifests before applying
+them.
+
+## Inspecting metrics from the command line
+
+For quick local debugging, the `print_metrics` helper fetches and pretty-prints the JSON
+metrics snapshot:
+
+```bash
+python -m tools.metrics_proxy.print_metrics \
+  --url http://localhost:8000/internal/metrics
+```
+
+This prints each gauge, counter, vector, and histogram with its labels and values so you
+can verify the proxy is tracking the expected statistics.
+
+## Embedding the recorder directly
+
+If you are embedding the proxy logic inside another service, you can import
+`ProxyMetricsRecorder` from `tools.metrics_proxy` and wire it into your own FastAPI app
+or request pipeline. The recorder mirrors the metrics defined in `vllm.v1.metrics`
+(`Gauge`, `Counter`, `Histogram`, and vector types) and provides helpers such as
+`increment_waiting`, `observe_queue_time`, and `finalize_request` to update counters in
+line with the native vLLM server implementation.

--- a/tools/metrics_proxy/__init__.py
+++ b/tools/metrics_proxy/__init__.py
@@ -1,0 +1,7 @@
+"""Utilities for proxying OpenAI-compatible requests while collecting vLLM metrics."""
+
+from .metrics_recorder import (ProxyMetricsRecorder, RequestOutcome,
+                               RequestSummary)
+from .proxy_server import create_app
+
+__all__ = ["ProxyMetricsRecorder", "RequestOutcome", "RequestSummary", "create_app"]

--- a/tools/metrics_proxy/custom_rest_ls.py
+++ b/tools/metrics_proxy/custom_rest_ls.py
@@ -1,0 +1,140 @@
+"""this module defines the RESTful web service app for the project."""
+
+from contextlib import asynccontextmanager
+import os
+
+from fastapi import FastAPI, Request
+from fastapi.responses import Response
+from prometheus_client import (
+    CONTENT_TYPE_LATEST,
+    REGISTRY,
+    CollectorRegistry,
+    generate_latest,
+)
+from prometheus_client.multiprocess import MultiProcessCollector
+
+from light_serve.serve.backends.base_backend import BaseLLMBackend
+from light_serve.serve.factory.backend_factory import backend_factory
+from light_serve.serve.openai.protocol import (
+    ChatCompletionRequest,
+    CompletionRequest,
+    DetokenizeRequest,
+    EmbeddingRequest,
+    TokenizeChatRequest,
+    TokenizeCompletionRequest,
+)
+
+# Global variables
+serving_model: BaseLLMBackend = None
+model_name: str = None
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Initialize the model at statup the service."""
+    global serving_model, model_name  # noqa: F824
+
+    # Retrieve runtime configs passed from `start_model`
+    runtime_configs = app.state.runtime_configs
+    model_config_dict = runtime_configs["model_config_dict"]
+
+    # Update model config dict with runtime configurations
+    model_config_dict.update(
+        {
+            "model_name": runtime_configs["model_name"],
+            "backend": runtime_configs["backend"],
+            "distributed_backend": runtime_configs["distributed_backend"],
+            "disable_cuda_graph": runtime_configs["disable_cuda_graph"],
+            "enforce_eager": runtime_configs["enforce_eager"],
+            "reasoning_parser": runtime_configs["reasoning_parser"],
+            "enable_auto_tool_choice": runtime_configs["enable_auto_tool_choice"],
+            "tool_call_parser": runtime_configs["tool_call_parser"],
+            "enable_prefix_caching": runtime_configs["enable_prefix_caching"],
+            "trust_remote_code": runtime_configs["trust_remote_code"],
+            "max_num_seqs": runtime_configs["max_num_seqs"],
+            "is_embedding": runtime_configs["is_embedding"],
+            "enable_expert_parallel": runtime_configs["enable_expert_parallel"],
+            "pipeline_parallel_size": runtime_configs["pipeline_parallel_size"],
+        }
+    )
+
+    print(f"Initializing model with config: {model_config_dict}")
+    backend_class = backend_factory(runtime_configs["backend"])
+    serving_model = backend_class(**model_config_dict)
+    await serving_model.start_server_or_load_model()
+    app.state.serving_model = serving_model  # Attach the backend to the app's state
+    yield
+    # Clean up resources if needed
+    await serving_model.service_shutdown()
+    print("Shutting down vllm_backend.")
+
+
+app = FastAPI(lifespan=lifespan)
+
+
+@app.on_event("startup")
+async def initialize():
+    """Initialize the model at statup the service."""
+    pass
+
+
+@app.get("/health")
+async def health(self) -> Response:
+    """Health check."""
+    return Response(status_code=200)
+
+
+@app.post("/v1/chat/completions", response_model=None)
+async def create_chat_completion(request: ChatCompletionRequest, raw_request: Request):
+    """Open AI Chat completions endpoint."""
+    return await serving_model.chat_completion(request, raw_request)
+
+
+@app.post("/v1/completions", response_model=None)
+async def create_completion(request: CompletionRequest, raw_request: Request):
+    """Open AI Chat completions endpoint."""
+    return await serving_model.completion(request, raw_request)
+
+
+@app.post("/tokenize_completion", response_model=None)
+async def tokenize_completion(request: TokenizeCompletionRequest, raw_request: Request):
+    """Tokenize completion endpoint."""
+    return await serving_model.tokenize_completion(request, raw_request)
+
+
+@app.post("/tokenize_chat", response_model=None)
+async def tokenize_chat(request: TokenizeChatRequest, raw_request: Request):
+    """Tokenize chat endpoint."""
+    return await serving_model.tokenize_chat(request, raw_request)
+
+
+@app.post("/detokenize", response_model=None)
+async def detokenize(request: DetokenizeRequest, raw_request: Request):
+    """Open AI embeddings endpoint."""
+    return await serving_model.detokenize(request, raw_request)
+
+
+@app.post("/v1/embeddings", response_model=None)
+async def create_embedding(request: EmbeddingRequest, raw_request: Request):
+    """Open AI embeddings endpoint."""
+    return await serving_model.embedding(request, raw_request)
+
+
+@app.get("/metrics")
+async def metrics() -> Response:
+    """Prometheus metrics endpoint compatible with vLLM's exporter."""
+    # Use multiprocess collector if PROMETHEUS_MULTIPROC_DIR is set (vLLM MP frontend)
+    if os.environ.get("PROMETHEUS_MULTIPROC_DIR"):
+        registry = CollectorRegistry()
+        MultiProcessCollector(registry)
+        output = generate_latest(registry)
+    else:
+        output = generate_latest(REGISTRY)
+
+    return Response(content=output, media_type=CONTENT_TYPE_LATEST)
+
+
+@app.on_event("shutdown")
+async def shutdown():
+    """Stop the listener and backend when shutdown the service."""
+    await serving_model.service_shutdown()

--- a/tools/metrics_proxy/kubernetes/deployment.yaml
+++ b/tools/metrics_proxy/kubernetes/deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-proxy
+  labels:
+    app: metrics-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: metrics-proxy
+  template:
+    metadata:
+      labels:
+        app: metrics-proxy
+    spec:
+      containers:
+        - name: metrics-proxy
+          image: ghcr.io/example/vllm-metrics-proxy:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: PROXY_UPSTREAM_URL
+              value: http://vllm-backend:8000
+            - name: PROXY_MODEL_NAME
+              value: your-model-name
+            - name: PROXY_ENGINE_LABEL
+              value: proxy
+          ports:
+            - name: http
+              containerPort: 8000
+          readinessProbe:
+            httpGet:
+              path: /internal/healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /internal/healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi

--- a/tools/metrics_proxy/kubernetes/service.yaml
+++ b/tools/metrics_proxy/kubernetes/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: metrics-proxy
+  labels:
+    app: metrics-proxy
+spec:
+  selector:
+    app: metrics-proxy
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000

--- a/tools/metrics_proxy/metrics_recorder.py
+++ b/tools/metrics_proxy/metrics_recorder.py
@@ -1,0 +1,436 @@
+"""Metric collection utilities for the custom vLLM metrics proxy."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, Iterable, List, Optional
+
+from prometheus_client import (CollectorRegistry, Counter, Gauge, Histogram,
+                               generate_latest)
+
+from vllm.v1.metrics import reader as metrics_reader
+from vllm.v1.metrics.reader import Counter as CounterMetric
+from vllm.v1.metrics.reader import Gauge as GaugeMetric
+from vllm.v1.metrics.reader import Histogram as HistogramMetric
+from vllm.v1.metrics.reader import Metric as BaseMetric
+from vllm.v1.metrics.reader import Vector as VectorMetric
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RequestOutcome:
+    """Information gathered about a single proxied request."""
+
+    queue_time: float
+    inference_time: float
+    ttft: Optional[float]
+    prompt_tokens: Optional[int]
+    completion_tokens: Optional[int]
+    total_tokens: Optional[int]
+    finish_reasons: List[str]
+    max_tokens: Optional[int]
+    n: int
+    success: bool
+    status_code: int
+    stream: bool
+    error: Optional[str] = None
+
+
+@dataclass
+class RequestSummary:
+    """A human readable view of :class:`RequestOutcome`."""
+
+    queue_time: float
+    inference_time: float
+    e2e_time: float
+    ttft: Optional[float]
+    prefill_time: float
+    decode_time: float
+    inter_token_latency: Optional[float]
+    prompt_tokens: Optional[int]
+    completion_tokens: Optional[int]
+    total_tokens: Optional[int]
+    finish_reasons: List[str] = field(default_factory=list)
+    success: bool = True
+    status_code: int = 200
+    n: int = 1
+    max_tokens: Optional[int] = None
+
+
+def build_buckets(mantissa_lst: Iterable[int], max_value: int) -> List[int]:
+    """Build a list of monotonically increasing histogram buckets."""
+
+    exponent = 0
+    buckets: List[int] = []
+    while True:
+        for mantissa in mantissa_lst:
+            value = mantissa * 10**exponent
+            if value <= max_value:
+                buckets.append(value)
+            else:
+                return buckets
+        exponent += 1
+
+
+def build_1_2_5_buckets(max_value: int) -> List[int]:
+    """Convenience wrapper that produces 1/2/5 style histogram buckets."""
+
+    return build_buckets([1, 2, 5], max_value)
+
+
+class ProxyMetricsRecorder:
+    """Collects vLLM style Prometheus metrics for proxied requests."""
+
+    def __init__(self,
+                 model_name: str,
+                 engine_label: str = "proxy",
+                 *,
+                 max_model_len: int = 4096,
+                 registry: Optional[CollectorRegistry] = None) -> None:
+        self.model_name = model_name
+        self.engine_label = engine_label
+        self.registry = registry or CollectorRegistry()
+        self.max_model_len = max_model_len
+
+        labelnames = ["model_name", "engine"]
+        label_values = (self.model_name, self.engine_label)
+
+        # Scheduler gauges.
+        self._running_metric = Gauge(
+            "vllm:num_requests_running",
+            "Number of requests currently forwarded to the upstream server.",
+            labelnames=labelnames,
+            registry=self.registry,
+        ).labels(*label_values)
+        self._waiting_metric = Gauge(
+            "vllm:num_requests_waiting",
+            "Number of requests waiting for a free upstream slot.",
+            labelnames=labelnames,
+            registry=self.registry,
+        ).labels(*label_values)
+
+        # Cache related gauges/counters (recorded as zero – proxy cannot infer).
+        self._kv_cache_usage = Gauge(
+            "vllm:kv_cache_usage_perc",
+            "Proxy placeholder for KV cache usage (always 0).",
+            labelnames=labelnames,
+            registry=self.registry,
+        ).labels(*label_values)
+        self._kv_cache_usage.set(0.0)
+
+        self._prefix_cache_queries = Counter(
+            "vllm:prefix_cache_queries",
+            "Proxy placeholder for prefix cache queries (always 0).",
+            labelnames=labelnames,
+            registry=self.registry,
+        ).labels(*label_values)
+        self._prefix_cache_hits = Counter(
+            "vllm:prefix_cache_hits",
+            "Proxy placeholder for prefix cache hits (always 0).",
+            labelnames=labelnames,
+            registry=self.registry,
+        ).labels(*label_values)
+        self._num_preemptions = Counter(
+            "vllm:num_preemptions",
+            "Proxy placeholder for engine preemptions (always 0).",
+            labelnames=labelnames,
+            registry=self.registry,
+        ).labels(*label_values)
+
+        # Token accounting.
+        self._prompt_tokens = Counter(
+            "vllm:prompt_tokens",
+            "Number of prompt tokens processed by the proxy.",
+            labelnames=labelnames,
+            registry=self.registry,
+        ).labels(*label_values)
+        self._generation_tokens = Counter(
+            "vllm:generation_tokens",
+            "Number of generated tokens processed by the proxy.",
+            labelnames=labelnames,
+            registry=self.registry,
+        ).labels(*label_values)
+
+        self._request_success_metric = Counter(
+            "vllm:request_success",
+            "Count of successfully processed requests forwarded by the proxy.",
+            labelnames=labelnames + ["finished_reason"],
+            registry=self.registry,
+        )
+
+        # Token histograms.
+        self._prompt_tokens_hist = Histogram(
+            "vllm:request_prompt_tokens",
+            "Histogram of prompt tokens per request.",
+            buckets=build_1_2_5_buckets(self.max_model_len),
+            labelnames=labelnames,
+            registry=self.registry,
+        ).labels(*label_values)
+        self._generation_tokens_hist = Histogram(
+            "vllm:request_generation_tokens",
+            "Histogram of generated tokens per request.",
+            buckets=build_1_2_5_buckets(self.max_model_len),
+            labelnames=labelnames,
+            registry=self.registry,
+        ).labels(*label_values)
+        self._max_generation_tokens_hist = Histogram(
+            "vllm:request_max_num_generation_tokens",
+            "Histogram of requested max generation tokens.",
+            buckets=build_1_2_5_buckets(self.max_model_len),
+            labelnames=labelnames,
+            registry=self.registry,
+        ).labels(*label_values)
+        self._max_tokens_param_hist = Histogram(
+            "vllm:request_params_max_tokens",
+            "Histogram of the max_tokens parameter provided to the proxy.",
+            buckets=build_1_2_5_buckets(self.max_model_len),
+            labelnames=labelnames,
+            registry=self.registry,
+        ).labels(*label_values)
+        self._n_param_hist = Histogram(
+            "vllm:request_params_n",
+            "Histogram of the n parameter provided to the proxy.",
+            buckets=[1, 2, 5, 10, 20],
+            labelnames=labelnames,
+            registry=self.registry,
+        ).labels(*label_values)
+
+        # Timing histograms.
+        request_latency_buckets = [
+            0.3, 0.5, 0.8, 1.0, 1.5, 2.0, 2.5, 5.0, 10.0, 15.0, 20.0, 30.0,
+            40.0, 50.0, 60.0, 120.0, 240.0, 480.0, 960.0, 1920.0, 7680.0
+        ]
+        self._ttft_hist = Histogram(
+            "vllm:time_to_first_token_seconds",
+            "Histogram of observed time to first token.",
+            buckets=[
+                0.001, 0.005, 0.01, 0.02, 0.04, 0.06, 0.08, 0.1, 0.25, 0.5,
+                0.75, 1.0, 2.5, 5.0, 7.5, 10.0, 20.0, 40.0, 80.0, 160.0, 640.0,
+                2560.0
+            ],
+            labelnames=labelnames,
+            registry=self.registry,
+        ).labels(*label_values)
+        self._time_per_token_hist = Histogram(
+            "vllm:time_per_output_token_seconds",
+            "Histogram of average time per generated token (proxy estimate).",
+            buckets=[
+                0.01, 0.025, 0.05, 0.075, 0.1, 0.15, 0.2, 0.3, 0.4, 0.5, 0.75,
+                1.0, 2.5, 5.0, 7.5, 10.0, 20.0, 40.0, 80.0
+            ],
+            labelnames=labelnames,
+            registry=self.registry,
+        ).labels(*label_values)
+        self._inter_token_latency_hist = Histogram(
+            "vllm:inter_token_latency_seconds",
+            "Histogram of inter-token latency (proxy estimate).",
+            buckets=[
+                0.01, 0.025, 0.05, 0.075, 0.1, 0.15, 0.2, 0.3, 0.4, 0.5, 0.75,
+                1.0, 2.5, 5.0, 7.5, 10.0, 20.0, 40.0, 80.0
+            ],
+            labelnames=labelnames,
+            registry=self.registry,
+        ).labels(*label_values)
+        self._e2e_latency_hist = Histogram(
+            "vllm:e2e_request_latency_seconds",
+            "Histogram of end-to-end latency observed by the proxy.",
+            buckets=request_latency_buckets,
+            labelnames=labelnames,
+            registry=self.registry,
+        ).labels(*label_values)
+        self._queue_time_hist = Histogram(
+            "vllm:request_queue_time_seconds",
+            "Histogram of queue wait time before contacting the upstream server.",
+            buckets=request_latency_buckets,
+            labelnames=labelnames,
+            registry=self.registry,
+        ).labels(*label_values)
+        self._inference_time_hist = Histogram(
+            "vllm:request_inference_time_seconds",
+            "Histogram of total upstream processing time.",
+            buckets=request_latency_buckets,
+            labelnames=labelnames,
+            registry=self.registry,
+        ).labels(*label_values)
+        self._prefill_time_hist = Histogram(
+            "vllm:request_prefill_time_seconds",
+            "Histogram of estimated prefill time (proxied).",
+            buckets=request_latency_buckets,
+            labelnames=labelnames,
+            registry=self.registry,
+        ).labels(*label_values)
+        self._decode_time_hist = Histogram(
+            "vllm:request_decode_time_seconds",
+            "Histogram of estimated decode time (proxied).",
+            buckets=request_latency_buckets,
+            labelnames=labelnames,
+            registry=self.registry,
+        ).labels(*label_values)
+
+        self._running_count = 0
+        self._waiting_count = 0
+
+    # ------------------------------------------------------------------
+    # Gauge helpers
+    # ------------------------------------------------------------------
+    def increment_waiting(self) -> None:
+        self._waiting_count += 1
+        self._waiting_metric.set(self._waiting_count)
+
+    def decrement_waiting(self) -> None:
+        self._waiting_count = max(self._waiting_count - 1, 0)
+        self._waiting_metric.set(self._waiting_count)
+
+    def increment_running(self) -> None:
+        self._running_count += 1
+        self._running_metric.set(self._running_count)
+
+    def decrement_running(self) -> None:
+        self._running_count = max(self._running_count - 1, 0)
+        self._running_metric.set(self._running_count)
+
+    # ------------------------------------------------------------------
+    # Recording helpers
+    # ------------------------------------------------------------------
+    def observe_queue_time(self, value: float) -> None:
+        self._queue_time_hist.observe(max(value, 0.0))
+
+    def finalize_request(self, outcome: RequestOutcome) -> RequestSummary:
+        """Update Prometheus metrics using the provided outcome."""
+
+        e2e_time = outcome.queue_time + outcome.inference_time
+        prefill_time = 0.0
+        if outcome.ttft is not None:
+            prefill_time = max(min(outcome.ttft, outcome.inference_time), 0.0)
+            self._ttft_hist.observe(outcome.ttft)
+        decode_time = max(outcome.inference_time - prefill_time, 0.0)
+
+        self._e2e_latency_hist.observe(e2e_time)
+        self._inference_time_hist.observe(max(outcome.inference_time, 0.0))
+        self._prefill_time_hist.observe(prefill_time)
+        self._decode_time_hist.observe(decode_time)
+
+        inter_token_latency: Optional[float] = None
+        if outcome.completion_tokens and outcome.completion_tokens > 0 and decode_time > 0:
+            inter_token_latency = decode_time / outcome.completion_tokens
+            self._inter_token_latency_hist.observe(inter_token_latency)
+            self._time_per_token_hist.observe(inter_token_latency)
+
+        if outcome.prompt_tokens is not None:
+            self._prompt_tokens.inc(max(outcome.prompt_tokens, 0))
+            self._prompt_tokens_hist.observe(max(outcome.prompt_tokens, 0))
+        if outcome.completion_tokens is not None:
+            self._generation_tokens.inc(max(outcome.completion_tokens, 0))
+            self._generation_tokens_hist.observe(max(outcome.completion_tokens, 0))
+
+        if outcome.max_tokens is not None:
+            self._max_generation_tokens_hist.observe(max(outcome.max_tokens, 0))
+            self._max_tokens_param_hist.observe(max(outcome.max_tokens, 0))
+
+        self._n_param_hist.observe(max(outcome.n, 0))
+
+        if outcome.success:
+            finish_reasons = outcome.finish_reasons or ["stop"]
+            for reason in finish_reasons:
+                normalized = (reason or "unknown").lower()
+                self._request_success_metric.labels(self.model_name,
+                                                    self.engine_label,
+                                                    normalized).inc()
+        else:
+            finish_reasons = outcome.finish_reasons
+
+        summary = RequestSummary(queue_time=outcome.queue_time,
+                                 inference_time=outcome.inference_time,
+                                 e2e_time=e2e_time,
+                                 ttft=outcome.ttft,
+                                 prefill_time=prefill_time,
+                                 decode_time=decode_time,
+                                 inter_token_latency=inter_token_latency,
+                                 prompt_tokens=outcome.prompt_tokens,
+                                 completion_tokens=outcome.completion_tokens,
+                                 total_tokens=outcome.total_tokens,
+                                 finish_reasons=finish_reasons,
+                                 success=outcome.success,
+                                 status_code=outcome.status_code,
+                                 n=outcome.n,
+                                 max_tokens=outcome.max_tokens)
+
+        return summary
+
+    # ------------------------------------------------------------------
+    # Introspection helpers
+    # ------------------------------------------------------------------
+    def snapshot(self) -> Dict[str, List[Dict[str, Any]]]:
+        """Return a JSON serialisable snapshot of all vLLM metrics."""
+
+        grouped: Dict[str, List[Dict[str, Any]]] = {
+            "gauges": [],
+            "counters": [],
+            "histograms": [],
+            "vectors": [],
+        }
+        for metric in collect_metrics_from_registry(self.registry):
+            payload = asdict(metric)
+            if isinstance(metric, GaugeMetric):
+                grouped["gauges"].append(payload)
+            elif isinstance(metric, CounterMetric):
+                grouped["counters"].append(payload)
+            elif isinstance(metric, HistogramMetric):
+                grouped["histograms"].append(payload)
+            elif isinstance(metric, VectorMetric):
+                grouped["vectors"].append(payload)
+        return grouped
+
+    def render_prometheus(self) -> str:
+        """Render the stored metrics using Prometheus exposition format."""
+
+        return generate_latest(self.registry).decode("utf-8")
+
+
+def collect_metrics_from_registry(
+        registry: CollectorRegistry) -> List[BaseMetric]:
+    """Collect metrics from an arbitrary Prometheus registry."""
+
+    collected: List[BaseMetric] = []
+    for metric in registry.collect():
+        if not metric.name.startswith("vllm:"):
+            continue
+        if metric.type == "gauge":
+            samples = metrics_reader._get_samples(metric)
+            for sample in samples:
+                collected.append(
+                    GaugeMetric(name=metric.name,
+                                labels=dict(sample.labels),
+                                value=sample.value))
+        elif metric.type == "counter":
+            samples = metrics_reader._get_samples(metric, "_total")
+            if metric.name == "vllm:spec_decode_num_accepted_tokens_per_pos":
+                for labels, values in metrics_reader._digest_num_accepted_by_pos_samples(
+                        samples):
+                    collected.append(
+                        VectorMetric(name=metric.name,
+                                     labels=labels,
+                                     values=values))
+            else:
+                for sample in samples:
+                    collected.append(
+                        CounterMetric(name=metric.name,
+                                      labels=dict(sample.labels),
+                                      value=int(sample.value)))
+        elif metric.type == "histogram":
+            bucket_samples = metrics_reader._get_samples(metric, "_bucket")
+            count_samples = metrics_reader._get_samples(metric, "_count")
+            sum_samples = metrics_reader._get_samples(metric, "_sum")
+            for labels, buckets, count_value, sum_value in metrics_reader._digest_histogram(
+                    bucket_samples, count_samples, sum_samples):
+                collected.append(
+                    HistogramMetric(name=metric.name,
+                                    labels=labels,
+                                    buckets=buckets,
+                                    count=count_value,
+                                    sum=sum_value))
+        else:
+            logger.debug("Unsupported metric type encountered: %s", metric.type)
+    return collected

--- a/tools/metrics_proxy/print_metrics.py
+++ b/tools/metrics_proxy/print_metrics.py
@@ -1,0 +1,67 @@
+"""Utility to fetch and display metrics from the vLLM metrics proxy."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any, Dict, Iterable
+
+import httpx
+
+
+def fetch_metrics(url: str) -> Dict[str, Any]:
+    with httpx.Client(timeout=10.0) as client:
+        response = client.get(url)
+        response.raise_for_status()
+        return response.json()
+
+
+def print_metric_groups(metrics: Dict[str, Any]) -> None:
+    for gauge in metrics.get("gauges", []):
+        print(_format_value_metric(gauge, "gauge"))
+    for counter in metrics.get("counters", []):
+        print(_format_value_metric(counter, "counter"))
+    for vector in metrics.get("vectors", []):
+        print(_format_vector_metric(vector))
+    for histogram in metrics.get("histograms", []):
+        print(_format_histogram(histogram))
+
+
+def _format_value_metric(metric: Dict[str, Any], metric_type: str) -> str:
+    labels = json.dumps(metric.get("labels", {}), sort_keys=True)
+    value = metric.get("value")
+    return f"{metric['name']} ({metric_type}) labels={labels} value={value}"
+
+
+def _format_vector_metric(metric: Dict[str, Any]) -> str:
+    labels = json.dumps(metric.get("labels", {}), sort_keys=True)
+    values = metric.get("values", [])
+    return f"{metric['name']} (vector) labels={labels} values={values}"
+
+
+def _format_histogram(metric: Dict[str, Any]) -> str:
+    labels = json.dumps(metric.get("labels", {}), sort_keys=True)
+    buckets = metric.get("buckets", {})
+    count = metric.get("count")
+    total = metric.get("sum")
+    bucket_lines = ", ".join(f"{le}={value}" for le, value in buckets.items())
+    return (f"{metric['name']} (histogram) labels={labels} count={count} "
+            f"sum={total} buckets={{ {bucket_lines} }}")
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Print metrics from the proxy")
+    parser.add_argument("--url",
+                        default="http://localhost:8000/internal/metrics",
+                        help="URL of the proxy metrics endpoint")
+    return parser.parse_args(argv)
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    args = parse_args(argv)
+    metrics = fetch_metrics(args.url)
+    print_metric_groups(metrics)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/metrics_proxy/proxy_server.py
+++ b/tools/metrics_proxy/proxy_server.py
@@ -1,0 +1,536 @@
+"""FastAPI application that proxies OpenAI compatible chat completions and logs metrics."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import time
+import uuid
+from dataclasses import dataclass
+from typing import (Any, AsyncGenerator, Callable, Dict, Iterable, List, Mapping,
+                    Optional, Tuple)
+
+import httpx
+from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
+
+from .metrics_recorder import (ProxyMetricsRecorder, RequestOutcome,
+                               RequestSummary)
+
+logger = logging.getLogger(__name__)
+
+CHAT_COMPLETIONS_PATH = "/v1/chat/completions"
+
+
+@dataclass
+class ProxyConfig:
+    """Runtime configuration for the metrics proxy."""
+
+    upstream_url: str
+    model_name: str
+    engine_label: str = "proxy"
+    max_concurrency: int = 16
+    max_model_len: int = 4096
+    connect_timeout: float = 10.0
+    read_timeout: float = 600.0
+    write_timeout: float = 600.0
+    request_timeout: float = 600.0
+    expose_metrics_endpoint: bool = True
+
+    def normalized_upstream(self) -> str:
+        return self.upstream_url.rstrip("/")
+
+
+def create_app(config: ProxyConfig) -> FastAPI:
+    """Create a FastAPI application configured to proxy chat completions."""
+
+    app = FastAPI(title="vLLM Metrics Proxy")
+    metrics = ProxyMetricsRecorder(model_name=config.model_name,
+                                   engine_label=config.engine_label,
+                                   max_model_len=config.max_model_len)
+    semaphore = asyncio.Semaphore(config.max_concurrency)
+
+    app.state.metrics = metrics
+    app.state.semaphore = semaphore
+    app.state.config = config
+    app.state.client = None
+
+    @app.on_event("startup")
+    async def _startup() -> None:
+        timeout = httpx.Timeout(timeout=config.request_timeout,
+                                connect=config.connect_timeout,
+                                read=config.read_timeout,
+                                write=config.write_timeout,
+                                pool=None)
+        app.state.client = httpx.AsyncClient(
+            base_url=config.normalized_upstream(),
+            timeout=timeout,
+            follow_redirects=True,
+        )
+        logger.info("Metrics proxy started – forwarding to %s", config.upstream_url)
+
+    @app.on_event("shutdown")
+    async def _shutdown() -> None:
+        client: Optional[httpx.AsyncClient] = app.state.client
+        if client is not None:
+            await client.aclose()
+        logger.info("Metrics proxy stopped")
+
+    @app.post(CHAT_COMPLETIONS_PATH)
+    async def chat_completions(request: Request) -> Response:
+        client: httpx.AsyncClient = app.state.client
+        if client is None:
+            raise HTTPException(status_code=503, detail="Proxy not initialised")
+
+        metrics: ProxyMetricsRecorder = app.state.metrics
+        semaphore: asyncio.Semaphore = app.state.semaphore
+
+        req_id = uuid.uuid4().hex[:8]
+        arrival = time.perf_counter()
+        metrics.increment_waiting()
+        acquired = False
+        try:
+            await semaphore.acquire()
+            acquired = True
+        finally:
+            metrics.decrement_waiting()
+        if not acquired:
+            raise HTTPException(status_code=503, detail="Unable to acquire proxy slot")
+
+        queue_time = max(time.perf_counter() - arrival, 0.0)
+        metrics.observe_queue_time(queue_time)
+
+        try:
+            payload = await request.json()
+        except json.JSONDecodeError as exc:
+            semaphore.release()
+            logger.warning("[%s] Invalid JSON payload: %s", req_id, exc)
+            raise HTTPException(status_code=400,
+                                detail="Request body must be valid JSON") from exc
+
+        stream = bool(payload.get("stream", False))
+        n_param = _coerce_int(payload.get("n", 1), default=1)
+        max_tokens = _extract_max_tokens(payload)
+
+        headers = _filter_request_headers(request.headers)
+
+        metrics.increment_running()
+        start_forward = time.perf_counter()
+
+        if stream:
+            response = await _handle_streaming_request(req_id, client, payload,
+                                                        headers, metrics, semaphore,
+                                                        queue_time, start_forward,
+                                                        n_param, max_tokens)
+            return response
+
+        try:
+            upstream_response = await client.post(CHAT_COMPLETIONS_PATH,
+                                                  json=payload,
+                                                  headers=headers)
+        except httpx.HTTPError as exc:
+            metrics.decrement_running()
+            semaphore.release()
+            logger.exception("[%s] Upstream request failed: %s", req_id, exc)
+            raise HTTPException(status_code=502,
+                                detail="Failed to contact upstream server") from exc
+
+        inference_time = max(time.perf_counter() - start_forward, 0.0)
+        data: Optional[Dict[str, Any]] = None
+        if upstream_response.headers.get("content-type", "").startswith(
+                "application/json"):
+            try:
+                data = upstream_response.json()
+            except ValueError:
+                logger.warning("[%s] Failed to decode JSON response", req_id)
+        prompt_tokens, completion_tokens, total_tokens = _parse_usage(
+            data.get("usage") if isinstance(data, dict) else None)
+        finish_reasons = _extract_finish_reasons(data)
+        success = upstream_response.is_success
+
+        outcome = RequestOutcome(queue_time=queue_time,
+                                 inference_time=inference_time,
+                                 ttft=None,
+                                 prompt_tokens=prompt_tokens,
+                                 completion_tokens=completion_tokens,
+                                 total_tokens=total_tokens,
+                                 finish_reasons=finish_reasons,
+                                 max_tokens=max_tokens,
+                                 n=n_param,
+                                 success=success,
+                                 status_code=upstream_response.status_code,
+                                 stream=False)
+        summary = metrics.finalize_request(outcome)
+        metrics.decrement_running()
+        semaphore.release()
+        _log_request_summary(req_id, summary)
+
+        return Response(content=upstream_response.content,
+                        status_code=upstream_response.status_code,
+                        headers=_filter_response_headers(upstream_response.headers),
+                        media_type=upstream_response.headers.get("content-type"))
+
+    @app.get("/internal/metrics")
+    async def internal_metrics() -> Dict[str, List[Dict[str, Any]]]:
+        return metrics.snapshot()
+
+    if config.expose_metrics_endpoint:
+        @app.get("/metrics")
+        async def prometheus_metrics() -> PlainTextResponse:
+            body = metrics.render_prometheus()
+            return PlainTextResponse(content=body,
+                                     media_type="text/plain; version=0.0.4")
+
+    @app.get("/internal/healthz")
+    async def healthz() -> Dict[str, str]:
+        return {"status": "ok"}
+
+    return app
+
+
+async def _handle_streaming_request(
+    req_id: str,
+    client: httpx.AsyncClient,
+    payload: Dict[str, Any],
+    headers: Mapping[str, str],
+    metrics: ProxyMetricsRecorder,
+    semaphore: asyncio.Semaphore,
+    queue_time: float,
+    start_forward: float,
+    n_param: int,
+    max_tokens: Optional[int],
+) -> StreamingResponse:
+    upstream_cm = client.stream("POST", CHAT_COMPLETIONS_PATH, json=payload,
+                                headers=headers)
+    try:
+        upstream_response = await upstream_cm.__aenter__()
+    except httpx.HTTPError as exc:
+        metrics.decrement_running()
+        semaphore.release()
+        logger.exception("[%s] Upstream streaming request failed: %s", req_id, exc)
+        raise HTTPException(status_code=502,
+                            detail="Failed to contact upstream server") from exc
+
+    finish_reasons: Dict[int, str] = {}
+    usage_payload: Optional[Dict[str, Any]] = None
+    buffer = ""
+    first_token_time: Optional[float] = None
+
+    async def event_generator() -> AsyncGenerator[bytes, None]:
+        nonlocal buffer, usage_payload, first_token_time
+        try:
+            async for chunk in upstream_response.aiter_bytes():
+                if chunk:
+                    now = time.perf_counter()
+                    text = chunk.decode("utf-8", errors="ignore")
+                    buffer += text
+                    buffer, usage_payload, first_token_time = _process_sse_buffer(
+                        buffer, now, finish_reasons, usage_payload,
+                        first_token_time)
+                    yield chunk
+        finally:
+            # Process any remaining buffered data
+            if buffer:
+                buffer, usage_payload, first_token_time = _process_sse_buffer(
+                    buffer, time.perf_counter(), finish_reasons,
+                    usage_payload, first_token_time)
+            inference_time = max(time.perf_counter() - start_forward, 0.0)
+            ttft = None
+            if first_token_time is not None:
+                ttft = max(first_token_time - start_forward, 0.0)
+            prompt_tokens, completion_tokens, total_tokens = _parse_usage(
+                usage_payload)
+            outcome = RequestOutcome(
+                queue_time=queue_time,
+                inference_time=inference_time,
+                ttft=ttft,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                total_tokens=total_tokens,
+                finish_reasons=list(finish_reasons.values()),
+                max_tokens=max_tokens,
+                n=n_param,
+                success=upstream_response.is_success,
+                status_code=upstream_response.status_code,
+                stream=True,
+            )
+            summary = metrics.finalize_request(outcome)
+            metrics.decrement_running()
+            semaphore.release()
+            await upstream_cm.__aexit__(None, None, None)
+            _log_request_summary(req_id, summary)
+
+    headers = _filter_response_headers(upstream_response.headers)
+    media_type = upstream_response.headers.get("content-type", "text/event-stream")
+    return StreamingResponse(event_generator(),
+                             status_code=upstream_response.status_code,
+                             headers=headers,
+                             media_type=media_type)
+
+
+def _process_sse_buffer(
+    buffer: str,
+    event_time: float,
+    finish_reasons: Dict[int, str],
+    usage_payload: Optional[Dict[str, Any]],
+    first_token_time: Optional[float],
+) -> Tuple[str, Optional[Dict[str, Any]], Optional[float]]:
+    while True:
+        if "\n" not in buffer:
+            return buffer, usage_payload, first_token_time
+        line, buffer = buffer.split("\n", 1)
+        line = line.rstrip("\r")
+        if not line:
+            continue
+        if not line.startswith("data:"):
+            continue
+        data = line[len("data:"):].strip()
+        if not data or data == "[DONE]":
+            continue
+        try:
+            payload = json.loads(data)
+        except json.JSONDecodeError:
+            logger.debug("Failed to decode SSE payload: %s", data)
+            continue
+        usage_payload, first_token_time = _handle_streaming_payload(
+            payload, event_time, finish_reasons, usage_payload,
+            first_token_time)
+    return buffer, usage_payload, first_token_time
+
+
+def _handle_streaming_payload(
+    payload: Dict[str, Any],
+    event_time: float,
+    finish_reasons: Dict[int, str],
+    usage_payload: Optional[Dict[str, Any]],
+    first_token_time: Optional[float],
+) -> Tuple[Optional[Dict[str, Any]], Optional[float]]:
+    if "usage" in payload and isinstance(payload["usage"], dict):
+        usage_payload = payload["usage"]
+
+    for choice in payload.get("choices", []):
+        if not isinstance(choice, dict):
+            continue
+        finish_reason = choice.get("finish_reason")
+        index = _coerce_int(choice.get("index", 0), default=0)
+        if finish_reason:
+            finish_reasons[index] = finish_reason
+        delta = choice.get("delta") or {}
+        if delta:
+            if any(delta.get(key) for key in ("content", "text")):
+                first_token_time = event_time if first_token_time is None else first_token_time
+            tool_calls = delta.get("tool_calls")
+            if tool_calls:
+                first_token_time = event_time if first_token_time is None else first_token_time
+
+    return usage_payload, first_token_time
+
+
+def _parse_usage(usage: Optional[Dict[str, Any]]) -> Tuple[Optional[int], Optional[int], Optional[int]]:
+    if not usage or not isinstance(usage, dict):
+        return None, None, None
+    prompt = _coerce_int(usage.get("prompt_tokens"))
+    completion = _coerce_int(usage.get("completion_tokens"))
+    total = _coerce_int(usage.get("total_tokens"))
+    return prompt, completion, total
+
+
+def _extract_finish_reasons(data: Optional[Dict[str, Any]]) -> List[str]:
+    choices = data.get("choices") if isinstance(data, dict) else None
+    if not isinstance(choices, list):
+        return []
+    reasons: List[str] = []
+    for choice in choices:
+        if isinstance(choice, dict) and choice.get("finish_reason"):
+            reasons.append(choice["finish_reason"])
+    return reasons
+
+
+def _extract_max_tokens(payload: Mapping[str, Any]) -> Optional[int]:
+    for key in ("max_completion_tokens", "max_tokens", "max_new_tokens",
+                "max_output_tokens"):
+        if key in payload:
+            value = _coerce_int(payload.get(key))
+            if value is not None:
+                return value
+    return None
+
+
+def _coerce_int(value: Any, *, default: Optional[int] = None) -> Optional[int]:
+    if value is None:
+        return default
+    if isinstance(value, int):
+        return value
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _filter_request_headers(headers: Mapping[str, str]) -> Dict[str, str]:
+    excluded = {"host", "content-length"}
+    return {k: v for k, v in headers.items() if k.lower() not in excluded}
+
+
+def _filter_response_headers(headers: Mapping[str, str]) -> Dict[str, str]:
+    excluded = {"content-length", "transfer-encoding", "connection"}
+    filtered = {k: v for k, v in headers.items() if k.lower() not in excluded}
+    # Streaming responses expect this header to be present.
+    if "content-type" not in {k.lower() for k in filtered}:
+        filtered["content-type"] = "text/event-stream"
+    return filtered
+
+
+def _log_request_summary(req_id: str, summary: RequestSummary) -> None:
+    fields = [
+        f"status={summary.status_code}",
+        f"success={summary.success}",
+        f"queue={summary.queue_time:.3f}s",
+        f"inference={summary.inference_time:.3f}s",
+        f"e2e={summary.e2e_time:.3f}s",
+    ]
+    if summary.ttft is not None:
+        fields.append(f"ttft={summary.ttft:.3f}s")
+    if summary.inter_token_latency is not None:
+        fields.append(f"avg_token_latency={summary.inter_token_latency:.3f}s")
+    if summary.prompt_tokens is not None:
+        fields.append(f"prompt_tokens={summary.prompt_tokens}")
+    if summary.completion_tokens is not None:
+        fields.append(f"completion_tokens={summary.completion_tokens}")
+    if summary.max_tokens is not None:
+        fields.append(f"max_tokens={summary.max_tokens}")
+    if summary.finish_reasons:
+        fields.append(f"finish_reasons={summary.finish_reasons}")
+    logger.info("Proxy metrics [%s]: %s", req_id, ", ".join(fields))
+
+
+def _parse_bool_env(value: str) -> bool:
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"Cannot interpret '{value}' as a boolean")
+
+
+def _override_with_env(parser: argparse.ArgumentParser, args: argparse.Namespace,
+                       dest: str, env_var: str,
+                       *, caster: Optional[Callable[[str], Any]] = None) -> None:
+    raw_value = os.getenv(env_var)
+    if raw_value is None:
+        return
+    default_value = parser.get_default(dest)
+    current_value = getattr(args, dest)
+    if current_value != default_value:
+        # The user explicitly supplied this value on the CLI; respect it.
+        return
+    try:
+        value = caster(raw_value) if caster is not None else raw_value
+    except ValueError as exc:
+        parser.error(f"Environment variable {env_var} has an invalid value: {exc}")
+    setattr(args, dest, value)
+
+
+def parse_args(argv: Optional[Iterable[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the vLLM metrics proxy.")
+    parser.add_argument("--upstream-url", default=None,
+                        help="Base URL of the upstream OpenAI compatible server")
+    parser.add_argument("--model-name", default=None,
+                        help="Name of the served model (used for metrics labels)")
+    parser.add_argument("--engine-label", default="proxy",
+                        help="Engine label attached to emitted metrics")
+    parser.add_argument("--host", default="0.0.0.0",
+                        help="Listen address for the proxy server")
+    parser.add_argument("--port", type=int, default=8000,
+                        help="Listen port for the proxy server")
+    parser.add_argument("--max-concurrency", type=int, default=16,
+                        help="Maximum number of concurrent upstream requests")
+    parser.add_argument("--max-model-len", type=int, default=4096,
+                        help="Model context length used for histogram buckets")
+    parser.add_argument("--connect-timeout", type=float, default=10.0,
+                        help="Connection timeout when contacting upstream")
+    parser.add_argument("--read-timeout", type=float, default=600.0,
+                        help="Read timeout when contacting upstream")
+    parser.add_argument("--write-timeout", type=float, default=600.0,
+                        help="Write timeout when contacting upstream")
+    parser.add_argument("--request-timeout", type=float, default=600.0,
+                        help="Overall request timeout for upstream operations")
+    parser.add_argument("--disable-metrics-endpoint", action="store_true",
+                        help="Do not expose the /metrics Prometheus endpoint")
+    parser.add_argument("--log-level", default="INFO",
+                        help="Logging level (DEBUG, INFO, WARNING, ...)")
+    args = parser.parse_args(argv)
+
+    # Allow environment variables to provide configuration defaults.
+    env_upstream = (os.getenv("PROXY_UPSTREAM_URL")
+                    or os.getenv("UPSTREAM_URL"))
+    if args.upstream_url is None and env_upstream:
+        args.upstream_url = env_upstream
+    env_model = (os.getenv("PROXY_MODEL_NAME")
+                 or os.getenv("MODEL_NAME"))
+    if args.model_name is None and env_model:
+        args.model_name = env_model
+    if not args.upstream_url:
+        parser.error("--upstream-url (or PROXY_UPSTREAM_URL) is required")
+    if not args.model_name:
+        parser.error("--model-name (or PROXY_MODEL_NAME) is required")
+
+    _override_with_env(parser, args, "engine_label", "PROXY_ENGINE_LABEL")
+    _override_with_env(parser, args, "host", "PROXY_HOST")
+    _override_with_env(parser, args, "port", "PROXY_PORT", caster=int)
+    _override_with_env(parser, args, "max_concurrency", "PROXY_MAX_CONCURRENCY",
+                       caster=int)
+    _override_with_env(parser, args, "max_model_len", "PROXY_MAX_MODEL_LEN",
+                       caster=int)
+    _override_with_env(parser, args, "connect_timeout", "PROXY_CONNECT_TIMEOUT",
+                       caster=float)
+    _override_with_env(parser, args, "read_timeout", "PROXY_READ_TIMEOUT",
+                       caster=float)
+    _override_with_env(parser, args, "write_timeout", "PROXY_WRITE_TIMEOUT",
+                       caster=float)
+    _override_with_env(parser, args, "request_timeout", "PROXY_REQUEST_TIMEOUT",
+                       caster=float)
+    _override_with_env(parser, args, "log_level", "PROXY_LOG_LEVEL")
+
+    disable_env = os.getenv("PROXY_DISABLE_METRICS_ENDPOINT")
+    if disable_env is not None:
+        try:
+            disable_value = _parse_bool_env(disable_env)
+        except ValueError as exc:
+            parser.error(f"Environment variable PROXY_DISABLE_METRICS_ENDPOINT has an "
+                         f"invalid value: {exc}")
+        if args.disable_metrics_endpoint == parser.get_default(
+                "disable_metrics_endpoint"):
+            args.disable_metrics_endpoint = disable_value
+
+    return args
+
+
+def main(argv: Optional[Iterable[str]] = None) -> None:
+    args = parse_args(argv)
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO),
+                        format="%(asctime)s %(levelname)s %(name)s %(message)s")
+
+    config = ProxyConfig(upstream_url=args.upstream_url,
+                         model_name=args.model_name,
+                         engine_label=args.engine_label,
+                         max_concurrency=args.max_concurrency,
+                         max_model_len=args.max_model_len,
+                         connect_timeout=args.connect_timeout,
+                         read_timeout=args.read_timeout,
+                         write_timeout=args.write_timeout,
+                         request_timeout=args.request_timeout,
+                         expose_metrics_endpoint=not args.disable_metrics_endpoint)
+
+    app = create_app(config)
+
+    import uvicorn
+
+    uvicorn.run(app, host=args.host, port=args.port, log_level=args.log_level.lower())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a metrics recorder that mirrors vLLM Prometheus gauges, counters and histograms for proxied requests
- build a FastAPI-based /v1/chat/completions proxy that forwards traffic, gathers latency/token usage metrics, and exposes JSON/Prometheus endpoints
- provide a helper script to pull and print the proxy's metrics snapshot
- document installation and usage instructions for the metrics proxy tools, including containerization and Kubernetes deployment guidance
- add environment-variable driven configuration, a Dockerfile, and Kubernetes manifests so the proxy can run as a frontend service

## Testing
- python -m compileall tools/metrics_proxy

------
https://chatgpt.com/codex/tasks/task_e_68c9bb7eeb7c8326a6f5bc4d334a752c