### PR TITLE
Filter repeated empty chat stream deltas

### DIFF
--- a/docker/Dockerfile.openai_empty_delta
+++ b/docker/Dockerfile.openai_empty_delta
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+# This image layers the empty-delta streaming fix on top of the published
+# vLLM OpenAI-compatible server image.
+FROM vllm/openai:latest
+
+# Copy the patched OpenAI serving components into a temporary build context.
+COPY vllm/entrypoints/openai/serving_chat.py /tmp/vllm_patch/serving_chat.py
+COPY vllm/entrypoints/openai/streaming_utils.py /tmp/vllm_patch/streaming_utils.py
+
+# Update the installed vLLM package with the patched streaming helpers.
+RUN python - <<'PY'
+import pathlib
+import shutil
+import vllm
+
+pkg_dir = pathlib.Path(vllm.__file__).resolve().parent
+openai_dir = pkg_dir / "entrypoints" / "openai"
+openai_dir.mkdir(parents=True, exist_ok=True)
+
+shutil.copyfile("/tmp/vllm_patch/serving_chat.py", openai_dir / "serving_chat.py")
+shutil.copyfile("/tmp/vllm_patch/streaming_utils.py",
+                openai_dir / "streaming_utils.py")
+PY

--- a/docker/Dockerfile.openai_empty_delta
+++ b/docker/Dockerfile.openai_empty_delta
@@ -3,7 +3,7 @@
 
 # This image layers the empty-delta streaming fix on top of the published
 # vLLM OpenAI-compatible server image.
-FROM vllm/openai:latest
+FROM vllm/vllm-openai:latest
 
 # Copy the patched OpenAI serving components into a temporary build context.
 COPY vllm/entrypoints/openai/serving_chat.py /tmp/vllm_patch/serving_chat.py

--- a/tests/entrypoints/openai/test_streaming_utils.py
+++ b/tests/entrypoints/openai/test_streaming_utils.py
@@ -1,4 +1,5 @@
-from vllm.entrypoints.openai.streaming_utils import _is_empty_content_only_delta
+from vllm.entrypoints.openai.streaming_utils import (EmptyDeltaTracker,
+                                                     _is_empty_content_only_delta)
 
 
 class _DummyDelta:
@@ -13,9 +14,10 @@ class _DummyDelta:
 
 class _DummyChoice:
 
-    def __init__(self, delta, finish_reason=None) -> None:
+    def __init__(self, delta, *, index=0, finish_reason=None) -> None:
         self.delta = delta
         self.finish_reason = finish_reason
+        self.index = index
 
 
 def test_is_empty_content_only_delta_true_for_content_only():
@@ -31,3 +33,39 @@ def test_is_empty_content_only_delta_false_when_other_fields_present():
 
     assert _is_empty_content_only_delta(choice_with_role) is False
     assert _is_empty_content_only_delta(choice_without_delta) is False
+
+
+def test_empty_delta_tracker_tracks_per_choice_index():
+    tracker = EmptyDeltaTracker()
+
+    first_empty = _DummyChoice(delta=_DummyDelta(content=""), index=0)
+    second_empty_same_choice = _DummyChoice(delta=_DummyDelta(content=""),
+                                            index=0)
+    first_empty_other_choice = _DummyChoice(delta=_DummyDelta(content=""),
+                                            index=1)
+
+    assert tracker.should_suppress(first_empty) is False
+    assert tracker.should_suppress(second_empty_same_choice) is True
+    assert tracker.should_suppress(first_empty_other_choice) is False
+
+
+def test_empty_delta_tracker_allows_final_empty_chunk():
+    tracker = EmptyDeltaTracker()
+
+    assert tracker.should_suppress(
+        _DummyChoice(delta=_DummyDelta(content=""), index=2)) is False
+
+    final_chunk = _DummyChoice(delta=_DummyDelta(content=""),
+                               index=2,
+                               finish_reason="stop")
+    assert tracker.should_suppress(final_chunk) is False
+
+
+def test_empty_delta_tracker_handles_missing_index():
+    tracker = EmptyDeltaTracker()
+
+    first = _DummyChoice(delta=_DummyDelta(content=""), index=None)
+    second = _DummyChoice(delta=_DummyDelta(content=""), index=None)
+
+    assert tracker.should_suppress(first) is False
+    assert tracker.should_suppress(second) is True

--- a/tests/entrypoints/openai/test_streaming_utils.py
+++ b/tests/entrypoints/openai/test_streaming_utils.py
@@ -1,0 +1,33 @@
+from vllm.entrypoints.openai.streaming_utils import _is_empty_content_only_delta
+
+
+class _DummyDelta:
+
+    def __init__(self, **payload) -> None:
+        self._payload = payload
+
+    def model_dump(self, *, exclude_none: bool, exclude_unset: bool):
+        del exclude_none, exclude_unset
+        return {k: v for k, v in self._payload.items() if v is not None}
+
+
+class _DummyChoice:
+
+    def __init__(self, delta, finish_reason=None) -> None:
+        self.delta = delta
+        self.finish_reason = finish_reason
+
+
+def test_is_empty_content_only_delta_true_for_content_only():
+    choice = _DummyChoice(delta=_DummyDelta(content=""))
+
+    assert _is_empty_content_only_delta(choice) is True
+
+
+def test_is_empty_content_only_delta_false_when_other_fields_present():
+    choice_with_role = _DummyChoice(
+        delta=_DummyDelta(role="assistant", content=""))
+    choice_without_delta = _DummyChoice(delta=None)
+
+    assert _is_empty_content_only_delta(choice_with_role) is False
+    assert _is_empty_content_only_delta(choice_without_delta) is False

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -34,6 +34,8 @@ from vllm.entrypoints.openai.protocol import (
     ChatCompletionStreamResponse, ChatMessage, DeltaFunctionCall, DeltaMessage,
     DeltaToolCall, ErrorResponse, FunctionCall, FunctionDefinition,
     PromptTokenUsageInfo, RequestResponseMetadata, ToolCall, UsageInfo)
+from vllm.entrypoints.openai.streaming_utils import \
+    _is_empty_content_only_delta
 from vllm.entrypoints.openai.serving_engine import (OpenAIServing,
                                                     clamp_prompt_logprobs)
 from vllm.entrypoints.openai.serving_models import OpenAIServingModels
@@ -477,6 +479,7 @@ class OpenAIServingChat(OpenAIServing):
         created_time = int(time.time())
         chunk_object_type: Final = "chat.completion.chunk"
         first_iteration = True
+        empty_content_chunk_emitted = False
 
         # Send response for each token for each request.n (index)
         num_choices = 1 if request.n is None else request.n
@@ -1074,6 +1077,16 @@ class OpenAIServingChat(OpenAIServing):
                             completion_tokens=completion_tokens,
                             total_tokens=num_prompt_tokens + completion_tokens,
                         )
+
+                    delta_is_empty_content_only = _is_empty_content_only_delta(
+                        choice_data)
+                    if delta_is_empty_content_only:
+                        if choice_data.finish_reason is None:
+                            if empty_content_chunk_emitted:
+                                continue
+                            empty_content_chunk_emitted = True
+                        else:
+                            empty_content_chunk_emitted = True
 
                     data = chunk.model_dump_json(exclude_unset=True)
                     yield f"data: {data}\n\n"

--- a/vllm/entrypoints/openai/streaming_utils.py
+++ b/vllm/entrypoints/openai/streaming_utils.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Utility helpers shared across OpenAI-compatible streaming code."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _is_empty_content_only_delta(choice: Any) -> bool:
+    """Return True if ``choice`` has a delta exactly {"content": ""}."""
+
+    delta = getattr(choice, "delta", None)
+    if delta is None:
+        return False
+
+    delta_payload = delta.model_dump(exclude_none=True, exclude_unset=True)
+    return (delta_payload.get("content") == ""
+            and len(delta_payload) == 1)
+

--- a/vllm/entrypoints/openai/streaming_utils.py
+++ b/vllm/entrypoints/openai/streaming_utils.py
@@ -7,6 +7,10 @@ from __future__ import annotations
 
 from typing import Any
 
+__all__ = ["EmptyDeltaTracker", "_is_empty_content_only_delta"]
+
+_NO_INDEX_SENTINEL = object()
+
 
 def _is_empty_content_only_delta(choice: Any) -> bool:
     """Return True if ``choice`` has a delta exactly {"content": ""}."""
@@ -18,4 +22,32 @@ def _is_empty_content_only_delta(choice: Any) -> bool:
     delta_payload = delta.model_dump(exclude_none=True, exclude_unset=True)
     return (delta_payload.get("content") == ""
             and len(delta_payload) == 1)
+
+
+class EmptyDeltaTracker:
+    """Track empty deltas so repeated blanks can be filtered per-choice."""
+
+    def __init__(self) -> None:
+        self._seen_indexes: set[object] = set()
+
+    def _index_key(self, choice: Any) -> object:
+        index = getattr(choice, "index", None)
+        return index if index is not None else _NO_INDEX_SENTINEL
+
+    def should_suppress(self, choice: Any) -> bool:
+        """Return True if the ``choice`` should be filtered out."""
+
+        if not _is_empty_content_only_delta(choice):
+            return False
+
+        key = self._index_key(choice)
+        if getattr(choice, "finish_reason", None) is not None:
+            self._seen_indexes.add(key)
+            return False
+
+        if key in self._seen_indexes:
+            return True
+
+        self._seen_indexes.add(key)
+        return False
 


### PR DESCRIPTION
## Summary
- drop repeated streaming chunks whose delta is only an empty content field while preserving the first such event
- factor the empty-delta detection into a reusable helper for OpenAI streaming
- add unit tests for the empty-delta detector

## Testing
- python - <<'PY'
from tests.entrypoints.openai.test_streaming_utils import (
    test_is_empty_content_only_delta_true_for_content_only,
    test_is_empty_content_only_delta_false_when_other_fields_present,
)

test_is_empty_content_only_delta_true_for_content_only()
test_is_empty_content_only_delta_false_when_other_fields_present()
print("tests passed")
PY

------
https://chatgpt.com/codex/tasks/task_e_68d4dd9f1acc8326b6e9b51daea1d89b